### PR TITLE
Support bdd with Guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,15 @@ source :rubygems
 
 gemspec
 
-gem 'debugger'
+gem 'debugger', :platforms => 'ruby_19'
+gem 'ruby-debug', :platforms => 'ruby_18'
+
+case RUBY_PLATFORM
+when /darwin/
+  gem "growl"
+when /win32/
+  gem "notifu"
+when /linux/
+  gem "libnotify"
+end
+

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,15 @@
+guard 'spork', :cucumber => false, :rspec_env => { 'RAILS_ENV' => 'test' } do
+  watch('spec/spec_helper.rb') { :rspec }
+end
+
+guard 'rspec', :version => 2, :cli => "--color --format nested --drb" do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+end
+
+guard 'cucumber', :cli => '--format pretty --color' do
+  watch(%r{^features/.+\.feature$})
+  watch(%r{^features/support/.+$})          { 'features' }
+  watch(%r{^features/step_definitions/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'features' }
+end

--- a/gauntlt.gemspec
+++ b/gauntlt.gemspec
@@ -17,10 +17,12 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_development_dependency "cucumber"
   s.add_development_dependency "rspec", "~> 2.11"
   s.add_development_dependency "aruba"
   s.add_development_dependency "rake"
+  s.add_development_dependency "guard-rspec"
+  s.add_development_dependency "guard-spork"
+  s.add_development_dependency "guard-cucumber"
 
   s.add_runtime_dependency "cucumber"
   s.add_runtime_dependency "aruba"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,11 +5,17 @@ require 'rubygems'
 require 'bundler'
 Bundler.setup
 
-require 'gauntlt'
+require 'spork'
 
-require 'aruba/api'
+Spork.prefork do
+  require 'aruba/api'
+  require 'rspec'
+  RSpec.configure do |c|
+    c.include Aruba::Api
+    c.color = true
+  end  
+end
 
-RSpec.configure do |c|
-  c.include Aruba::Api
-  c.color = true
+Spork.each_run do
+  require 'gauntlt'
 end


### PR DESCRIPTION
Uses guard, following the bdd mentality

-Conditionally requires notification libraries
-Sets up rspec tests with DRB for fast awesomesauce
-Conditionally requires the debugger for compatibility
