### PR TITLE
Solve: #45 Creation of a 'binary gauntlt' version

### DIFF
--- a/config/warble.rb
+++ b/config/warble.rb
@@ -1,0 +1,6 @@
+Warbler::Config.new do |config|
+  config.dirs = %w(bin features vendor gem_tasks lib)
+  config.includes = FileList["*.rb"] # I don't know why I have to force the
+  # ruby file inclusion, but for now it solves the problem described
+  # at https://github.com/gauntlt/gauntlt/issues/45
+end


### PR DESCRIPTION
After digging around the generation of the jar (more on #45 ), I was able to found that for some reason warble wasn't including the ruby files.

With this PR you can run `warble && java  -jar gauntlt.jar --help` and see https://gist.github.com/sarcilav/5260236

PD: I haven't tested out to much the jar, but I think that having a working jar is a good start
