### PR TITLE
Add command to list all available step definitions

### DIFF
--- a/bin/gauntlt
+++ b/bin/gauntlt
@@ -21,6 +21,15 @@ EOS
       :multi => true
 
   opt :list, "List defined attacks"
+  opt :steps, "List all available step definitions"
+end
+
+if opts[:steps]
+  require 'gauntlt/stepdef'
+
+  defined_steps = Gauntlt::Stepdef.definitions
+  defined_steps.each {|x| puts "#{x['kind']} -- #{x['source']}"}
+  exit(0)
 end
 
 opts[:path] = if ARGV.empty?
@@ -36,3 +45,4 @@ if opts[:list]
 else
   Gauntlt.attack( opts[:path], opts[:tags].join(',') )
 end
+

--- a/lib/gauntlt/stepdef.rb
+++ b/lib/gauntlt/stepdef.rb
@@ -1,0 +1,40 @@
+require 'cucumber'
+
+module Gauntlt
+  class Stepdef
+    # Force a dry-run and report just the step names
+    ARGS = ["-d", "-f", "stepdefs"]
+
+    class << self
+      def definitions
+        new.definitions
+      end
+    end
+
+    def initialize
+      config = Cucumber::Cli::Configuration.new(STDOUT, STDERR)
+      config.parse!(ARGS)
+      runtime = Cucumber::Runtime.new(config)
+      @steps = get_steps(runtime)
+    end
+
+    def get_steps(runtime)
+      runtime.send(:load_step_definitions)
+      runtime.instance_variable_get("@support_code").step_definitions
+    end
+
+    def definitions
+      stepdefs = []
+      @steps.sort{|a,b| a.to_hash['source'] <=> a.to_hash['source']}.each do |stepdef|
+        stepdef_hash = stepdef.to_hash
+        stepdef_hash['kind'] = if stepdef.file =~ /aruba/ # stepdef.file_colon_line
+                                 "aruba"
+                               else
+                                 "gauntlt"
+                               end
+        stepdefs << stepdef_hash
+      end
+      stepdefs
+    end
+  end
+end

--- a/test/gauntlt/stepdef_test.rb
+++ b/test/gauntlt/stepdef_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'gauntlt/stepdef'
+
+mock_cuke = Object.new
+
+mock_support_code = Object.new
+
+hash_steps = [{:source => "some", :file => "aruba"},
+              {:source => "other", :file => "other"}]
+mock_steps = hash_steps.map do |step|
+  OpenStruct.new(step.merge({:to_hash => step}))
+end
+
+subject = stub(Cucumber::Runtime, :spy => :new,
+               :return => mock_cuke) do
+  stub(mock_cuke, :spy => :load_step_definitions,
+       :return => mock_cuke) do
+    stub(mock_cuke, :spy => :instance_variable_get,
+         :return => mock_support_code) do
+      stub(mock_support_code, :spy => :step_definitions,
+           :return => mock_steps) do
+        Gauntlt::Stepdef.new
+      end
+    end
+  end
+end
+
+# .initialize
+# set the steps from cucumber
+lambda do
+  assert subject.instance_variable_get("@steps"), :== => mock_steps
+end.call
+
+# .definitions
+# set the proper step kind
+lambda do
+  assert subject.definitions.first['kind'], :== => "aruba"
+  assert subject.definitions.last['kind'], :== => "gauntlt"
+end.call


### PR DESCRIPTION
This should solve #46
I found basically to approach, the first one was to manually scan the files, and the second one (the one that I used for this PR) was to use cucumber internals to get the steps definitions.

I've also added hirb to have nice output (sample output https://gist.github.com/sarcilav/5267167)

PD: As this is my first PR that plays a bit with the internals of cucumber and gauntlt, I'm not sure if I'm missing important things within code style and contribution rules.
