### PR TITLE
Issue 65: Update default hostname in cucumber profile from google.com to scanme.nmap.org

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,1 +1,1 @@
-default: TEST_HOSTNAME=google.com
+default: TEST_HOSTNAME=scanme.nmap.org

--- a/examples/nmap/simple-env-var.attack
+++ b/examples/nmap/simple-env-var.attack
@@ -1,3 +1,4 @@
+@slow
 Feature: simple nmap attack (sanity check)
 
   Background:
@@ -17,8 +18,8 @@ Feature: simple nmap attack (sanity check)
       """
       nmap -p <http_port>,<https_port> <hostname>
       """
-    Then the output should contain:
+    Then the output should match /80.tcp\s+open/      
+    And the output should not match:
       """
-      80/tcp  open  http
-      443/tcp open  https
+      443/tcp\s+open 
       """

--- a/features/attacks/nmap.feature
+++ b/features/attacks/nmap.feature
@@ -23,7 +23,7 @@ Feature: nmap attack
     When I run `gauntlt simple-env-var.attack`
     Then it should pass with:
       """
-      5 steps (5 passed)
+      6 steps (6 passed)
       """
 
   Scenario: OS detection nmap attack


### PR DESCRIPTION
Updated the hostname in the cucumber profile and adjusted the attack files and rake tests accordingly

HOWTO wiki article is complete as well!
https://github.com/boldersecurity/gauntlt/wiki/Using-Cucumber-Profiles-and-Environment-Variables-with-Gauntlt

If all looks well and wiki article integrated, I'll post to the gauntlt mailing list.
