### PR TITLE
gauntlt 1.0.7 with locking to cucumber version

### DIFF
--- a/features/attack.feature
+++ b/features/attack.feature
@@ -100,7 +100,7 @@ Feature: Verify the attack behaviour is correct
     When I run `gauntlt`
     Then it should fail with:
       """
-      Undefined gauntlt attack step
+      Not a recognized gauntlt attack step
       """
 
   Scenario: No attack files in default path

--- a/gauntlt.gemspec
+++ b/gauntlt.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "arachni"
 
-  s.add_runtime_dependency 'cucumber', '= 1.3.10', '= 1.3.10'
+  s.add_runtime_dependency 'cucumber', '= 1.3.11', '= 1.3.11'
   s.add_runtime_dependency 'aruba', '= 0.5.4', '0.5.4'
   s.add_runtime_dependency "nokogiri", "~>1.5.0"
   s.add_runtime_dependency "trollop"

--- a/lib/gauntlt/patches/errors.rb
+++ b/lib/gauntlt/patches/errors.rb
@@ -1,9 +1,10 @@
 module Cucumber
   class Undefined < StandardError
     def initialize(step_name)
-      super %{Undefined gauntlt attack step: "#{step_name}"}
+      super %{Not a recognized gauntlt attack step: "#{step_name}"\nCheck available gauntlt steps with this command 'gauntlt --allsteps'}
       @step_name = step_name
     end
   end
 end
  
+

--- a/lib/gauntlt/runtime.rb
+++ b/lib/gauntlt/runtime.rb
@@ -20,7 +20,7 @@ module Gauntlt
     end
 
     def cuke_cli
-      args =  attack_files + ['--strict', '--require', self.class.adapters_dir]
+      args =  attack_files + ['--strict', '--no-snippets', '--require', self.class.adapters_dir]
       args += ['--tags', tags] unless tags.empty?
       args += ['--format', format] unless format.nil?
 

--- a/lib/gauntlt/version.rb
+++ b/lib/gauntlt/version.rb
@@ -1,3 +1,3 @@
 module Gauntlt
-  VERSION = "1.0.8"
+  VERSION = "1.0.7"
 end

--- a/vendor/gruyere/source/.gitignore
+++ b/vendor/gruyere/source/.gitignore
@@ -1,0 +1,1 @@
+stored-data.txt


### PR DESCRIPTION
Version 1.0.7
- Locked to cucumber 1.3.11
- Locked to aruba 0.5.4
- Changed wording on error messages for unrecognized steps
