### PR TITLE
Problem with cucumber 1.3.15 appears to be resolved with 1.3.18

### DIFF
--- a/gauntlt.gemspec
+++ b/gauntlt.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'arachni', '= 0.4.6'
 
-  s.add_runtime_dependency 'cucumber', '= 1.3.15'
+  s.add_runtime_dependency 'cucumber', '= 1.3.18'
   s.add_runtime_dependency 'aruba', '= 0.5.4'
   s.add_runtime_dependency 'nokogiri', '= 1.6.1'
   s.add_runtime_dependency 'trollop', '~> 2.0'


### PR DESCRIPTION
I had problems running with Cucumber 1.3.15.  Gave errors such as:  
  Getting `undefined method 'unpack' for nil:NilClass`

I am testing with Ruby 2.2.2 but all seemed to work properly once I bumped the cucumber version.