### PR TITLE
initial support for passing output dir as gauntlt CLI option

### DIFF
--- a/bin/gauntlt
+++ b/bin/gauntlt
@@ -11,7 +11,7 @@ opts = Trollop::options do
 gauntlt is a ruggedization framework that helps you be mean to your code
 
 Usage:
-       gauntlt <path>+ [--tags TAG_EXPRESSION] [--format FORMAT]
+       gauntlt <path>+ [--tags TAG_EXPRESSION] [--format FORMAT] [--out OUTDIR]
 
 Options:
 EOS
@@ -21,13 +21,17 @@ EOS
       :multi => true
 
   opt :list, "List defined attacks"
-  
+
   opt :steps, "List the gauntlt step definitions that can be used inside of attack files"
 
   opt :allsteps, "List all available step definitions including aruba step definitions which help with file and parsing operations"
 
   opt :format, "Available formats: html, json, junit, progress",
       :type => String
+
+  opt :out, "Output Directory: used for junit output",
+      :type => String
+
 end
 
 opts[:path] = if ARGV.empty?
@@ -50,6 +54,5 @@ elsif opts[:allsteps]
   puts "\nGauntlt Attack Steps"
   puts all_step_defs[:gauntlt].sort
 else
-  Gauntlt.attack( opts[:path], opts[:tags].join(','), opts[:format] )
+  Gauntlt.attack( opts[:path], opts[:tags].join(','), opts[:format], opts[:out] )
 end
-

--- a/examples/curl/cookies.attack
+++ b/examples/curl/cookies.attack
@@ -13,5 +13,4 @@ Scenario: Verify server is returning the cookies expected
     """
   Then the following cookies should be received:
     | name | secure | _rest              |
-    | PREF | false  | {}                 |
     | NID  | false  | {'HttpOnly': None} |

--- a/lib/gauntlt.rb
+++ b/lib/gauntlt.rb
@@ -17,7 +17,7 @@ module Gauntlt
   ATTACK_ADAPTERS_DIR = File.join(GAUNTLT_DIR, 'attack_adapters')
 
   ATTACK_ADAPTERS_GLOB_PATTERN = ATTACK_ADAPTERS_DIR + '/*.rb'
-  
+
   ATTACK_ALIASES_DIR = File.join(GAUNTLT_DIR, 'attack_aliases')
   ATTACK_ALIASES_GLOB_PATTERN = ATTACK_ALIASES_DIR + '/*.json'
 
@@ -32,8 +32,8 @@ module Gauntlt
       end.sort
     end
 
-    def attack(path, tags=[], format="")
-      Attack.new(path, tags, format).run
+    def attack(path, tags=[], format="", out="")
+      Attack.new(path, tags, format, out).run
     end
 
     def stepdefs(path, tags=[])

--- a/lib/gauntlt/attack.rb
+++ b/lib/gauntlt/attack.rb
@@ -4,8 +4,8 @@ module Gauntlt
   class Attack
     attr_accessor :runtime
 
-    def initialize(path, tags=[], format="")
-      self.runtime = Runtime.new(path, tags, format)
+    def initialize(path, tags=[], format="", out="")
+      self.runtime = Runtime.new(path, tags, format, out)
     end
 
     def run

--- a/lib/gauntlt/runtime.rb
+++ b/lib/gauntlt/runtime.rb
@@ -9,13 +9,14 @@ module Gauntlt
     class NoFilesFound < StandardError; end
     class ExecutionFailed < StandardError; end
 
-    attr_accessor :path, :attack_files, :tags, :format
+    attr_accessor :path, :attack_files, :tags, :format, :out
 
-    def initialize(path, tags=[], format="")
+    def initialize(path, tags=[], format="", out="")
       self.path         = path
       self.attack_files = self.class.attack_files_for(path)
       self.tags         = tags
       self.format       = format
+      self.out          = out
       raise NoFilesFound.new("No files found in path: #{path}") if attack_files.empty?
     end
 
@@ -23,6 +24,7 @@ module Gauntlt
       args =  attack_files + ['--strict', '--no-snippets', '--require', self.class.adapters_dir]
       args += ['--tags', tags] unless tags.empty?
       args += ['--format', format] unless format.nil?
+      args += ['--out', out] unless out.nil?
 
       Cucumber::Cli::Main.new(args)
     end
@@ -36,7 +38,7 @@ module Gauntlt
     end
 
     def execute!
-      cuke_cli.execute! 
+      cuke_cli.execute!
     end
 
     class << self


### PR DESCRIPTION
As suggested in issue #72 , there should be a way to pass an output directory to cucumber in order to use the JUnit formatter.    This PR provides very basic functionality, and no new tests.

