### PR TITLE
Curl cookies

### DIFF
--- a/examples/curl/cookies.attack
+++ b/examples/curl/cookies.attack
@@ -13,5 +13,5 @@ Scenario: Verify server is returning the cookies expected
     curl --include --location --head --silent <hostname>
     """
   Then the following cookies should be received:
-    | name | secure | _rest              |
-    | NID  | false  | {'HttpOnly': None} |
+    | name | secure | httponly |
+    | NID  | na     | true     |

--- a/examples/curl/cookies.attack
+++ b/examples/curl/cookies.attack
@@ -13,5 +13,5 @@ Scenario: Verify server is returning the cookies expected
     curl --include --location --head --silent <hostname>
     """
   Then the following cookies should be received:
-    | name | secure | httponly |
-    | NID  | na     | true     |
+    | name | httponly |
+    | NID  | true     |

--- a/lib/gauntlt/attack_adapters/curl.rb
+++ b/lib/gauntlt/attack_adapters/curl.rb
@@ -10,9 +10,17 @@ end
 Then /^the following cookies should be received:$/ do |table|
   set_cookies( cookies_for_last_curl_request )
 
-  names = table.hashes.map{|h| h['name'] }
-  names.each do |name|
-    expect(cookies.any?{|s| s =~ /^#{name}/}).to eq(true)
-    # TODO: check other values in table
+  table.hashes.each do |h|
+    cookie_by_name = cookies.select{|e| e[:name] == h['name']}
+    expect(cookie_by_name.any?).to be_truthy
+
+    c = cookie_by_name.first
+
+    h.each do |k,v|
+      unless v == "na"
+        expect(c[k.to_sym]).to_not be_nil
+        expect(c[k.to_sym]).to eq(v)
+      end
+    end
   end
 end

--- a/lib/gauntlt/attack_adapters/curl.rb
+++ b/lib/gauntlt/attack_adapters/curl.rb
@@ -17,7 +17,7 @@ Then /^the following cookies should be received:$/ do |table|
     c = cookie_by_name.first
 
     h.each do |k,v|
-      unless v == "na"
+      unless v.empty?
         expect(c[k.to_sym]).to_not be_nil
         expect(c[k.to_sym]).to eq(v)
       end

--- a/lib/gauntlt/attack_adapters/support/cookie_helper.rb
+++ b/lib/gauntlt/attack_adapters/support/cookie_helper.rb
@@ -17,18 +17,11 @@ module Gauntlt
             k, v     = stripped.split('=').map(&:downcase)
 
             case k
-            when 'expires'
-              inj[:expires]  = v
-            when 'max-age'
-              inj[:max_age]  = v
             when 'secure'
-              inj[:secure]   = "true"
             when 'httponly'
-              inj[:httponly] = "true"
-            when 'samesite'
-              inj[:samesite] = v
+              inj[k.to_sym] = "true"
             else
-              inj[k.to_sym]  = v
+              inj[k.gsub(/-/,"_").to_sym]  = v
             end
 
             inj

--- a/lib/gauntlt/attack_adapters/support/cookie_helper.rb
+++ b/lib/gauntlt/attack_adapters/support/cookie_helper.rb
@@ -5,7 +5,34 @@ module Gauntlt
         raise "no curl output found!" unless @raw_curl_response
 
         @raw_curl_response.scan(/^Set-Cookie:.+$/).map do |header|
-          "#{$1}=#{$2}" if header =~ /^Set-Cookie: ([^=]+)=([^;]+;)/
+          cookie_data    = header.gsub(/^set-cookie: /i,'')
+          cookie         = {}
+          parts          = cookie_data.split(/;/).reject{ |c| c.empty? }
+          cookie[:name]  = parts[0].split(/=/)[0]
+          rest           = parts[0].split(/=/).drop(1)
+          cookie[:value] = rest.join('=')
+
+          parts.drop(1).inject(cookie) do |inj,p|
+            stripped = p.strip
+            k, v     = stripped.split('=').map(&:downcase)
+
+            case k
+            when 'expires'
+              inj[:expires]  = v
+            when 'max-age'
+              inj[:max_age]  = v
+            when 'secure'
+              inj[:secure]   = "true"
+            when 'httponly'
+              inj[:httponly] = "true"
+            when 'samesite'
+              inj[:samesite] = v
+            else
+              inj[k.to_sym]  = v
+            end
+
+            inj
+          end
         end
       end
 


### PR DESCRIPTION
Parse curl Set-Cookie header to enable verification of cookie attributes. This should address issue #101 